### PR TITLE
[LFXV2-11] Minor updates to complete integration with Project Service and Indexer Service

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Essential Commands
+
+### Build and Development
+
+```bash
+# Install dependencies and development tools
+make setup
+make deps
+
+# Generate API code from Goa design (required after design changes)
+make apigen
+# Or directly: goa gen github.com/linuxfoundation/lfx-v2-query-service/design
+
+# Build the application
+make build
+
+# Run locally with mock implementations (development)
+SEARCH_SOURCE=mock ACCESS_CONTROL_SOURCE=mock go run ./cmd
+
+# Run with OpenSearch and NATS (production-like)
+SEARCH_SOURCE=opensearch ACCESS_CONTROL_SOURCE=nats \
+OPENSEARCH_URL=http://localhost:9200 \
+OPENSEARCH_INDEX=resources \
+NATS_URL=nats://localhost:4222 \
+go run ./cmd
+```
+
+### Testing and Validation
+
+```bash
+# Run tests
+make test
+# Or: go test -v -race -coverprofile=coverage.out ./...
+
+# Run linting
+make lint
+# Or: golangci-lint run ./...
+
+# Run specific test
+go test -v -run TestResourceSearch ./internal/usecase/
+```
+
+### Docker Operations
+
+```bash
+# Build Docker image
+make docker-build
+
+# Run Docker container
+make docker-run
+```
+
+## Architecture Overview
+
+This service follows clean architecture principles with clear separation of concerns:
+
+### Layer Structure
+
+1. **Domain Layer** (`internal/domain/`)
+   - `model/`: Core business entities (Resource, SearchCriteria, AccessCheck)
+   - `port/`: Interfaces defining contracts (ResourceSearcher, AccessControlChecker)
+
+2. **Use Case Layer** (`internal/usecase/`)
+   - Business logic orchestration
+   - Coordinates between domain and infrastructure
+
+3. **Infrastructure Layer** (`internal/infrastructure/`)
+   - `opensearch/`: OpenSearch implementation for resource search
+   - `nats/`: NATS implementation for access control
+   - `mock/`: Mock implementations for testing
+
+4. **Presentation Layer** (`gen/`, `cmd/`)
+   - Generated Goa code for HTTP endpoints
+   - Service implementation connecting Goa to domain logic
+
+### Key Design Patterns
+
+- **Dependency Injection**: Concrete implementations injected in `cmd/main.go`
+- **Port/Adapter Pattern**: Domain interfaces (ports) with swappable implementations
+- **Repository Pattern**: Search and access control abstracted behind interfaces
+
+### API Design (Goa Framework)
+
+- Design specifications in `design/` directory
+- Generated code in `gen/` (DO NOT manually edit)
+- After design changes, always run `make apigen`
+
+### Request Flow
+
+1. HTTP request → Goa generated server (`gen/http/query_svc/server/`)
+2. Service layer (`cmd/query_svc/query_svc.go`)
+3. Use case orchestration (`internal/usecase/resource_search.go`)
+4. Domain interfaces called with concrete implementations
+5. Response formatted and returned through Goa
+
+### Configuration
+
+Environment variables control implementation selection:
+
+- `SEARCH_SOURCE`: "mock" or "opensearch"
+- `ACCESS_CONTROL_SOURCE`: "mock" or "nats"
+- Additional configs for OpenSearch and NATS connections
+
+### Testing Strategy
+
+- Unit tests use mock implementations
+- Integration tests can switch between real and mock implementations
+- Test files follow `*_test.go` pattern alongside implementation files

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ HTTP service for LFX API consumers to perform access-controlled queries for LFX 
 ## Architecture Overview
 
 The implementation follows the clean architecture principles where:
+
 - **Domain Layer**: Contains business logic and interfaces
 - **Service Layer**: Orchestrates business operations
 - **Infrastructure Layer**: Implements external dependencies
@@ -15,9 +16,7 @@ The implementation follows the clean architecture principles where:
 ```
 ├── .github/                        # Github files
 │   └── workflows/                  # Github Action workflow files
-├── deploy/                         # Contains Kubernetes/Helm manifests
-│   ├── k8s/                        # K8s manifests (raw YAML)
-│   └── charts/                     # Helm charts
+├── charts/                         # Helm charts
 ├── design/                         # GOA design specification files
 ├── gen/                            # GOA generated code (HTTP server, client, OpenAPI)
 ├── cmd/                            # Services (main packages)
@@ -35,30 +34,36 @@ The implementation follows the clean architecture principles where:
 ## Key Components
 
 ### Domain Layer (`internal/domain/`)
+
+- **ResourceService**: Contains business logic and validation
+
 #### Model (`internal/domain/model/`)
+
 - **Domain Models**: Core business entities and data structures
 - **Value Objects**: Immutable objects that represent domain concepts
 
 #### Ports (`internal/domain/port/`)
+
 - **ResourceSearcher Interface**: Defines the contract for resource search operations
 - **AccessControlChecker Interface**: Defines the contract for access control operations
 
 ### Use Case Layer (`internal/usecase/`)
+
 - **Business Logic**: Application-specific business rules and operations
 - **Use Case Orchestration**: Coordinates between domain models and infrastructure
-
-### Service Layer (`internal/service/`)
-- **ResourceService**: Contains business logic and validation
 
 ### Infrastructure Layer (`internal/infrastructure/`)
 
 #### OpenSearch Implementation
+
 The OpenSearch implementation includes query templates, a searcher, and a client for interacting with the OpenSearch cluster.
 
 #### NATS Implementation
+
 The NATS implementation consists of a client, access control logic, and request/response models for messaging and access control.
 
 ## Dependency Injection
+
 Dependency injection is performed in `cmd/main.go`, where the concrete implementations for resource search and access control are selected based on configuration and then injected into the service constructor.
 
 ## Benefits of This Architecture
@@ -82,6 +87,7 @@ make docker-build
 ### Running with Docker
 
 #### Basic Docker Run
+
 ```bash
 make docker-run
 ```
@@ -91,6 +97,7 @@ make docker-run
 ### Running Locally
 
 #### With Mock Implementation (Default for Development)
+
 ```bash
 # Using mock implementations
 SEARCH_SOURCE=mock ACCESS_CONTROL_SOURCE=mock go run cmd/main.go
@@ -100,6 +107,7 @@ SEARCH_SOURCE=mock ACCESS_CONTROL_SOURCE=mock go run cmd/main.go -p 3000
 ```
 
 #### With OpenSearch and NATS
+
 ```bash
 # Using OpenSearch and NATS (production-like setup)
 SEARCH_SOURCE=opensearch \
@@ -113,22 +121,27 @@ go run cmd/main.go
 ### Available Environment Variables
 
 **Search Implementation:**
+
 - `SEARCH_SOURCE`: Choose between "mock" or "opensearch" (default: "opensearch")
 
 **OpenSearch Configuration:**
+
 - `OPENSEARCH_URL`: OpenSearch URL (default: `http://localhost:9200`)
 - `OPENSEARCH_INDEX`: OpenSearch index name (default: "resources")
 
 **Access Control Implementation:**
+
 - `ACCESS_CONTROL_SOURCE`: Choose between "mock" or "nats" (default: "nats")
 
 **NATS Configuration:**
+
 - `NATS_URL`: NATS server URL (default: `nats://localhost:4222`)
 - `NATS_TIMEOUT`: Request timeout duration (default: "10s")
 - `NATS_MAX_RECONNECT`: Maximum reconnection attempts (default: "3")
 - `NATS_RECONNECT_WAIT`: Time between reconnection attempts (default: "2s")
 
 **Server Configuration:**
+
 - `-p`: HTTP port (default: "8080")
 - `-bind`: Interface to bind on (default: "*")
 - `-d`: Enable debug logging
@@ -142,6 +155,7 @@ GET /query/resources?name=committee&type=committee&v=1
 ```
 
 **Parameters:**
+
 - `name`: Resource name or alias (supports typeahead search)
 - `type`: Resource type to filter by
 - `parent`: Parent resource for hierarchical queries
@@ -151,6 +165,7 @@ GET /query/resources?name=committee&type=committee&v=1
 - `v`: API version (required)
 
 **Response:**
+
 ```json
 {
   "resources": [
@@ -216,6 +231,7 @@ go install goa.design/goa/v3/cmd/goa@latest
 ```
 
 Verify the installation:
+
 ```bash
 goa version
 ```
@@ -231,6 +247,7 @@ goa gen github.com/linuxfoundation/lfx-v2-query-service/design
 ```
 
 This command generates:
+
 - HTTP server and client code
 - OpenAPI specification
 - Service interfaces and types
@@ -250,15 +267,20 @@ This command generated the basic server structure, which was then customized and
 
 1. **Make design changes**: Edit files in the `design/` directory
 2. **Regenerate code**: Run `goa gen github.com/linuxfoundation/lfx-v2-query-service/design` after design changes
-3. **Build the project**: 
+3. **Build the project**:
+
    ```bash
    go build cmd
    ```
+
 4. **Run with mock data** (for development):
+
    ```bash
    SEARCH_SOURCE=mock ACCESS_CONTROL_SOURCE=mock go run ./cmd
    ```
+
 5. **Run tests**:
+
    ```bash
    go test ./...
    ```

--- a/charts/lfx-v2-query-service/templates/heimdall.yaml
+++ b/charts/lfx-v2-query-service/templates/heimdall.yaml
@@ -1,0 +1,13 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: query-svc
+  namespace: lfx
+spec:
+  forwardAuth:
+    address: {{ .Values.heimdall.url }}
+    authResponseHeaders:
+      - Authorization

--- a/charts/lfx-v2-query-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-query-service/templates/ruleset.yaml
@@ -15,7 +15,6 @@ spec:
         routes:
           - path: /query/resources
       execute:
-      execute:
         {{- if .Values.authelia.enabled }}
         - authenticator: authelia
         - contextualizer: authelia_userinfo

--- a/charts/lfx-v2-query-service/values.yaml
+++ b/charts/lfx-v2-query-service/values.yaml
@@ -29,4 +29,8 @@ authelia:
 
 # heimdall is the configuration for the heimdall middleware
 heimdall:
+  # enabled is a boolean to determine if the heimdall middleware is enabled
+  # If disabled, there will be no authorization check on the query routes
   enabled: true
+  # url is the URL of the heimdall server
+  url: http://heimdall.lfx.svc.cluster.local:4456

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -171,7 +171,10 @@ func searcherImpl(ctx context.Context) port.ResourceSearcher {
 		resourceSearcher = mock.NewMockResourceSearcher()
 
 	case "opensearch":
-		slog.InfoContext(ctx, "initializing opensearch resource searcher")
+		slog.InfoContext(ctx, "initializing opensearch resource searcher",
+			"url", opensearchURL,
+			"index", opensearchIndex,
+		)
 		opensearchConfig := opensearch.Config{
 			URL:   opensearchURL,
 			Index: opensearchIndex,

--- a/internal/infrastructure/nats/access_control.go
+++ b/internal/infrastructure/nats/access_control.go
@@ -33,7 +33,10 @@ func (n *NATSAccessControlChecker) CheckAccess(ctx context.Context, subj string,
 		Timeout: timeout,
 	})
 	if err != nil {
-		slog.ErrorContext(ctx, "NATS access control check failed", "error", err)
+		slog.ErrorContext(ctx, "NATS access control check failed",
+			"error", err,
+			"subject", subj,
+		)
 		return nil, fmt.Errorf("NATS access control check failed: %w", err)
 	}
 

--- a/internal/infrastructure/opensearch/searcher.go
+++ b/internal/infrastructure/opensearch/searcher.go
@@ -181,7 +181,10 @@ func NewSearcher(ctx context.Context, config Config) (port.ResourceSearcher, err
 	if errpensearchClient != nil {
 		return nil, errors.NewServiceUnavailable("failed to create OpenSearch client", errpensearchClient)
 	}
-	slog.InfoContext(ctx, "created OpenSearch client created successfully")
+	slog.InfoContext(ctx, "created OpenSearch client created successfully",
+		"url", config.URL,
+		"index", config.Index,
+	)
 
 	return &OpenSearchSearcher{
 		client: &httpClient{

--- a/pkg/constants/access_control.go
+++ b/pkg/constants/access_control.go
@@ -5,7 +5,7 @@ package constants
 
 const (
 	// AccessCheckSubject is the subject used for access control checks
-	AccessCheckSubject = "dev.lfx.access_check.request"
+	AccessCheckSubject = "lfx.access_check.request"
 	// AnonymousPrincipal is the identifier for anonymous users
 	AnonymousPrincipal = `_anonymous`
 	// PrincipalAttribute is the attribute used to indicate the principal in the logging context


### PR DESCRIPTION
Ticket: [LFXV2-11](https://linuxfoundation.atlassian.net/browse/LFXV2-11)

As I was integrating the https://github.com/linuxfoundation/lfx-v2-project-service and https://github.com/linuxfoundation/lfx-v2-indexer-service together, I also worked on ensuring that indexed data is queryable by this query service. I noticed that the NATS subject the service handles was slightly different as well as that there wasn't a heimdall middleware template for the helm chart. Other changes are minor to include a CLAUDE.md, run markdown lint, and log the opensearch URL when creating the opensearch client.