### PR TITLE
Allow RS256 or PS256 as JWT signing algorithm

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   license-header-check:
     name: License Header Check
-    uses: linuxfoundation/lfx-public-workflows/.github/workflows/license-header-check.yml@main
+    uses: linuxfoundation/lfx-public-workflows/.github/workflows/license-header-check.yml@c465d6571fa0b8be9d551d902955164ea04a00af
     with:
       copyright_line: "Copyright The Linux Foundation and each contributor to LFX."
       exclude_pattern: "gen/*"

--- a/charts/lfx-v2-query-service/Chart.yaml
+++ b/charts/lfx-v2-query-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-query-service
 description: LFX Platform V2 Query Service chart
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "latest"

--- a/charts/lfx-v2-query-service/templates/deployment.yaml
+++ b/charts/lfx-v2-query-service/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
                   key: PAGE_TOKEN_SECRET
             - name: JWKS_URL
               value: {{ .Values.jwks.url }}
+            - name: JWT_SIGNATURE_ALGORITHM
+              value: {{ .Values.jwt.signatureAlgorithm | default "PS256" }}
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name }}

--- a/charts/lfx-v2-query-service/values.yaml
+++ b/charts/lfx-v2-query-service/values.yaml
@@ -59,3 +59,5 @@ secret:
 
 jwks:
   url: http://lfx-platform-heimdall:4457/.well-known/jwks
+jwt:
+  signatureAlgorithm: PS256

--- a/cmd/query_svc/jwt.go
+++ b/cmd/query_svc/jwt.go
@@ -19,9 +19,10 @@ import (
 
 const (
 	// PS256 is the default for Heimdall's JWT finalizer.
-	signatureAlgorithm = validator.PS256
-	defaultIssuer      = "heimdall"
-	defaultAudience    = "lfx-v2-query-service"
+	ps256           = validator.PS256
+	rs256           = validator.RS256
+	defaultIssuer   = "heimdall"
+	defaultAudience = "lfx-v2-query-service"
 )
 
 var (
@@ -75,6 +76,10 @@ func SetupJWTAuth(ctx context.Context) {
 	}
 	provider := jwks.NewCachingProvider(issuer, 5*time.Minute, jwks.WithCustomJWKSURI(jwksURL))
 
+	signatureAlgorithm := ps256
+	if os.Getenv("JWT_SIGNATURE_ALGORITHM") == "RS256" {
+		signatureAlgorithm = rs256
+	}
 	// Set up the JWT validator.
 	audience := os.Getenv("AUDIENCE")
 	if audience == "" {


### PR DESCRIPTION
Add support for configurable JWT signature algorithm via JWT_SIGNATURE_ALGORITHM environment variable. The service now accepts both RS256 and PS256 algorithms, with PS256 remaining the default for backward compatibility with Heimdall's JWT finalizer.

Changes:
- Add JWT_SIGNATURE_ALGORITHM environment variable to deployment
- Update JWT validation to check algorithm from environment
- Bump chart version to 0.2.2
- Default to PS256 in Helm values

🤖 Generated with Claude Code