### PR TITLE
[LFXV2-197] Query Service: endpoint auth rules for org search

### DIFF
--- a/charts/lfx-v2-query-service/templates/heimdall-middleware.yaml
+++ b/charts/lfx-v2-query-service/templates/heimdall-middleware.yaml
@@ -33,3 +33,18 @@ spec:
     authResponseHeaders:
       - Authorization
 {{- end }}
+---
+{{- if .Values.orgSearch.rateLimit.enabled }}
+# Rate limiting middleware for organization search endpoint
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: org-search-rate-limit
+  namespace: {{ .Release.Namespace }}
+spec:
+  rateLimit:
+    # Global rate limiting across all users (shared Clearbit API quota)
+    period: {{ .Values.orgSearch.rateLimit.period }}
+    average: {{ .Values.orgSearch.rateLimit.requestsPerMinute }}
+    burst: {{ .Values.orgSearch.rateLimit.burstSize }}
+{{- end }}

--- a/charts/lfx-v2-query-service/templates/httproute.yaml
+++ b/charts/lfx-v2-query-service/templates/httproute.yaml
@@ -13,14 +13,37 @@ spec:
   hostnames:
   - "lfx-api.{{ .Values.lfx.domain }}"
   rules:
-  # Main application endpoints (with authentication)
+  # Organization search endpoint (with rate limiting + authentication)
+  {{- if .Values.orgSearch.rateLimit.enabled }}
+  - matches:
+    - path:
+        type: Exact
+        value: /query/orgs
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: traefik.io
+        kind: Middleware
+        name: org-search-rate-limit
+    {{- if .Values.heimdall.enabled }}
+    - type: ExtensionRef
+      extensionRef:
+        group: traefik.io
+        kind: Middleware
+        name: heimdall
+    {{- end }}
+    backendRefs:
+    - name: lfx-v2-query-service
+      port: {{ .Values.service.port }}
+  {{- end }}
+  # Main application endpoints (with authentication only)
   - matches:
     - path:
         type: Exact
         value: /query
     - path:
         type: PathPrefix
-        value: /query/
+        value: /query/resources
     - path:
         type: PathPrefix
         value: /_query/

--- a/charts/lfx-v2-query-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-query-service/templates/ruleset.yaml
@@ -45,3 +45,20 @@ spec:
           config:
             values:
               aud: lfx-v2-query-service
+    - id: "rule:lfx:lfx-v2-query-service:org-search"
+      match:
+        methods:
+          - GET
+        routes:
+          - path: /query/orgs
+      execute:
+        - authenticator: oidc
+        - authenticator: anonymous_authenticator
+        {{- if .Values.app.use_oidc_contextualizer }}
+        - contextualizer: oidc_contextualizer
+        {{- end }}
+        - authorizer: allow_all
+        - finalizer: create_jwt
+          config:
+            values:
+              aud: lfx-v2-query-service

--- a/charts/lfx-v2-query-service/values.yaml
+++ b/charts/lfx-v2-query-service/values.yaml
@@ -56,6 +56,20 @@ heimdall:
   add_middleware: false
   url: http://lfx-platform-heimdall.lfx.svc.cluster.local:4456
 
+# Rate limiting configuration for org search endpoint
+orgSearch:
+  rateLimit:
+    # enabled is a boolean to determine if rate limiting is enabled for org search
+    enabled: true
+    ## Token Bucket Behavior:
+    # Bucket starts with: 30 tokens (full capacity)
+    # Refill rate: 10 tokens per minute = 1 token every 6 seconds
+    period: 1m
+    # requestsPerMinute defines how many requests per minute are allowed per jwt token
+    requestsPerMinute: 10
+    # burstSize defines the maximum burst capacity (bucket size)
+    burstSize: 30
+
 # secret is the configuration for the Kubernetes Secret
 secret:
   # name is the name of the secret


### PR DESCRIPTION
## Overview 

* https://linuxfoundation.atlassian.net/browse/LFXV2-197

This pull request introduces rate limiting for the organization search endpoint in the LFX V2 Query Service Helm chart, along with related configuration and routing changes. The main goal is to control API usage for `/query/orgs` by applying a shared quota, while maintaining authentication and authorization mechanisms. The changes are grouped below by theme.

## Tests

### Endpoint Matching and Rate Limiting

Note: 404 is due to the `query/orgs` not being implemented yet (GOA error)

```
mauriciosalomao@Mauricios-MacBook-Pro lfx-v2-query-service % ./test-rate-limit.sh
🧪 Testing Rate Limiting for /query/orgs
📊 Rate Limit Configuration:
   • Burst Size: 30 tokens
   • Refill Rate: 10 tokens/minute (1 token every 6 seconds)
   • Expected first 429: Request 31
⏱️  Timing Analysis: Will measure request intervals and token refill
----------------------------------------
Request  1 (t=0.5s, Δ=0.5s): ⚠️  OTHER (404)
Request  2 (t=0.5s, Δ=0.0s): ⚠️  OTHER (404)
Request  3 (t=0.5s, Δ=0.0s): ⚠️  OTHER (404)
Request  4 (t=0.5s, Δ=0.0s): ⚠️  OTHER (404)
Request  5 (t=1.5s, Δ=1.0s): ⚠️  OTHER (404)
Request  6 (t=1.5s, Δ=0.0s): ⚠️  OTHER (404)
Request  7 (t=1.5s, Δ=0.0s): ⚠️  OTHER (404)
Request  8 (t=1.5s, Δ=0.0s): ⚠️  OTHER (404)
Request  9 (t=2.5s, Δ=1.0s): ⚠️  OTHER (404)
Request 10 (t=2.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 11 (t=2.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 12 (t=2.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 13 (t=3.5s, Δ=1.0s): ⚠️  OTHER (404)
Request 14 (t=3.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 15 (t=3.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 16 (t=3.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 17 (t=3.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 18 (t=4.5s, Δ=1.0s): ⚠️  OTHER (404)
Request 19 (t=4.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 20 (t=4.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 21 (t=4.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 22 (t=5.5s, Δ=1.0s): ⚠️  OTHER (404)
Request 23 (t=5.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 24 (t=5.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 25 (t=5.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 26 (t=5.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 27 (t=6.5s, Δ=1.0s): ⚠️  OTHER (404)
Request 28 (t=6.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 29 (t=6.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 30 (t=6.5s, Δ=0.0s): ⚠️  OTHER (404)
Request 31 (t=7.5s, Δ=1.0s): ⚠️  OTHER (404)
Request 32 (t=7.5s, Δ=0.0s): ❌ RATE LIMITED (429)
Request 33 (t=7.5s, Δ=0.0s): ❌ RATE LIMITED (429)
Request 34 (t=7.5s, Δ=0.0s): ❌ RATE LIMITED (429)
Request 35 (t=7.5s, Δ=0.0s): ❌ RATE LIMITED (429)
----------------------------------------
📊 RESULTS SUMMARY:
✅ Successful requests: 0
❌ Rate limited requests: 4
🎯 First 429 error on request: 32 (at t=7.53s)
⏱️  Timing Analysis:
   • Expected 429 at: ~3.0s (request 31)
   • Actual 429 at: 7.53s (request 32)
   • Time difference: 4.53s
   • Theoretical tokens refilled: 1.2 (1 token every 6s)

🎯 EXPECTED vs ACTUAL:
Expected successful requests: 30
Actual successful requests: 0
Expected first 429: Request 31
Actual first 429: Request 32
🔧 Rate limiting working but with timing variations (normal behavior)
```