### PR TITLE
[LFXV2-196] Query Service: allow for clearbit api key in helm chart

### DIFF
--- a/charts/lfx-v2-query-service/Chart.yaml
+++ b/charts/lfx-v2-query-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-query-service
 description: LFX Platform V2 Query Service chart
 type: application
-version: 0.2.4
+version: 0.2.5
 appVersion: "latest"

--- a/charts/lfx-v2-query-service/templates/deployment.yaml
+++ b/charts/lfx-v2-query-service/templates/deployment.yaml
@@ -16,27 +16,21 @@ spec:
       labels:
         app: lfx-v2-query-service
     spec:
+      serviceAccountName: {{ .Values.serviceAccount.name | default .Chart.Name }}
       containers:
         - name: app
           image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: OPENSEARCH_URL
-              value: {{.Values.opensearch.url}}
-            - name: NATS_URL
-              value: {{.Values.nats.url}}
-            - name: PAGE_TOKEN_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.secret.name }}
-                  key: PAGE_TOKEN_SECRET
-            - name: JWKS_URL
-              value: {{ .Values.jwks.url }}
-            - name: JWT_SIGNATURE_ALGORITHM
-              value: {{ .Values.jwt.signatureAlgorithm | default "PS256" }}
-          envFrom:
-            - secretRef:
-                name: {{ .Values.secret.name }}
+          {{- range $name, $config := .Values.app.environment }}
+          - name: {{ $name }}
+            {{- if $config.value }}
+            value: {{ $config.value | quote }}
+            {{- else if $config.valueFrom }}
+            valueFrom:
+              {{- toYaml $config.valueFrom | nindent 14 }}
+            {{- end }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.port }}
               name: web

--- a/charts/lfx-v2-query-service/templates/serviceaccount.yaml
+++ b/charts/lfx-v2-query-service/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/lfx-v2-query-service/values.yaml
+++ b/charts/lfx-v2-query-service/values.yaml
@@ -13,6 +13,24 @@ image:
 app:
   # use_oidc_contextualizer is a boolean to determine if the OIDC contextualizer should be used
   use_oidc_contextualizer: true
+  # environment is the configuration for the application environment
+  environment:
+    OPENSEARCH_URL:
+      value: http://opensearch-cluster-master:9200
+    NATS_URL:
+      value: nats://lfx-platform-nats.lfx.svc.cluster.local:4222
+    JWKS_URL:
+      value: http://lfx-platform-heimdall:4457/.well-known/jwks
+    JWT_SIGNATURE_ALGORITHM:
+      value: PS256
+    PAGE_TOKEN_SECRET:
+      valueFrom:
+        secretKeyRef:
+          name: lfx-v2-query-service-secrets
+          key: PAGE_TOKEN_SECRET
+    # CLEARBIT_CREDENTIAL is optional
+    CLEARBIT_CREDENTIAL:
+      value: null
 
 # traefik is the configuration for Traefik Gateway API routing
 traefik:
@@ -32,6 +50,18 @@ lfx:
 service:
   # port is the service port
   port: 8080
+
+# serviceAccount is the configuration for the Kubernetes service account
+serviceAccount:
+  # create specifies whether a service account should be created
+  create: true
+  # name is the name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # annotations to add to the service account
+  annotations: {}
+  # automountServiceAccountToken is a boolean to determine if the service account token should be automatically mounted
+  automountServiceAccountToken: true
 
 # nats is the configuration for the NATS server
 nats:


### PR DESCRIPTION
# Overview

* https://linuxfoundation.atlassian.net/browse/LFXV2-196

This pull request updates the Helm chart for the `lfx-v2-query-service` to improve configuration flexibility and security, particularly around environment variables and service account management. The main changes introduce a new way to define environment variables, add support for creating and customizing a Kubernetes service account, and update the chart version.

**Environment Variable Management:**
* Refactored environment variable configuration to use a new `app.environment` map in `values.yaml`, allowing both direct values and `valueFrom` sources such as secrets. This replaces the previous hardcoded environment variable definitions in `deployment.yaml` and enables easier customization and secret management. [[1]](diffhunk://#diff-1cc896c5098a663b38f25dfad024c9910e65fb7922397a210dca8301bc572c5bR19-R33) [[2]](diffhunk://#diff-673a145ff19731d93eb772ff20e944767b324dcad20873a296145eaf4efb3488R16-R33)

**Service Account Improvements:**
* Added configuration options for service account creation and customization under `serviceAccount` in `values.yaml`, including fields for name, annotations, and automounting the token.
* Introduced a new `serviceaccount.yaml` template to create the service account resource if enabled, using the provided configuration.
* Updated the deployment spec to reference the configurable service account name.

**Chart Version Update:**
* Bumped the chart version from `0.2.4` to `0.2.5` in `Chart.yaml` to reflect these changes.