### PR TITLE
[LFXV2-197] Add PathPrefix - _query

### DIFF
--- a/charts/lfx-v2-query-service/Chart.yaml
+++ b/charts/lfx-v2-query-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-query-service
 description: LFX Platform V2 Query Service chart
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: "latest"

--- a/charts/lfx-v2-query-service/templates/httproute.yaml
+++ b/charts/lfx-v2-query-service/templates/httproute.yaml
@@ -44,6 +44,9 @@ spec:
     - path:
         type: PathPrefix
         value: /query/resources
+    - path:
+        type: PathPrefix
+        value: /_query/
     {{- if .Values.heimdall.enabled }}
     filters:
     - type: ExtensionRef


### PR DESCRIPTION
## Overview

* https://linuxfoundation.atlassian.net/browse/LFXV2-197

### Tests

```
mauriciosalomao@Mauricios-MacBook-Pro ~ % curl --location 'http://lfx-api.k8s.orb.local:80/_query/openapi3.yaml' \
...
openapi: 3.0.3
info:
    title: LFX V2 - Query Service
    description: Query indexed resources
    version: 0.0.1
servers:
    - url: http://localhost:80
      description: Default server for lfx-v2-query-service
paths:
    /query/orgs:
        get:
            tags:
                - query-svc
            ....
```