### PR TITLE
Bump chart version to 0.4.5

### DIFF
--- a/charts/lfx-v2-query-service/Chart.yaml
+++ b/charts/lfx-v2-query-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-query-service
 description: LFX Platform V2 Query Service chart
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: "latest"


### PR DESCRIPTION
This pull request makes a minor version bump to the Helm chart for the LFX Platform V2 Query Service.

* Updated the `version` field in `charts/lfx-v2-query-service/Chart.yaml` from `0.4.4` to `0.4.5` to reflect a new chart release.