### PR TITLE
Update HTTPRoute and RuleSet with missing fields

### DIFF
--- a/charts/lfx-v2-query-service/Chart.yaml
+++ b/charts/lfx-v2-query-service/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: lfx-v2-query-service
 description: LFX Platform V2 Query Service chart
 type: application
-version: 0.4.6
+version: 0.4.7
 appVersion: "latest"

--- a/charts/lfx-v2-query-service/templates/httproute.yaml
+++ b/charts/lfx-v2-query-service/templates/httproute.yaml
@@ -8,7 +8,9 @@ metadata:
   namespace: {{ .Values.lfx.namespace }}
 spec:
   parentRefs:
-  - name: {{ .Values.traefik.gateway.name }}
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: {{ .Values.traefik.gateway.name }}
     namespace: {{ .Values.traefik.gateway.namespace }}
   hostnames:
   - "lfx-api.{{ .Values.lfx.domain }}"
@@ -34,7 +36,9 @@ spec:
       {{- end }}
     {{- end }}
     backendRefs:
-    - name: lfx-v2-query-service
+    - group: ""
+      kind: Service
+      name: lfx-v2-query-service
       port: {{ .Values.service.port }}
   # Main application endpoints (with authentication only)
   - matches:
@@ -56,5 +60,7 @@ spec:
         name: heimdall
     {{- end }}
     backendRefs:
-    - name: lfx-v2-query-service
+    - group: ""
+      kind: Service
+      name: lfx-v2-query-service
       port: {{ .Values.service.port }}

--- a/charts/lfx-v2-query-service/templates/ruleset.yaml
+++ b/charts/lfx-v2-query-service/templates/ruleset.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   rules:
     - id: "rule:lfx:lfx-v2-query-service:openapi:get"
+      allow_encoded_slashes: "off"
       match:
         methods:
           - GET
@@ -29,6 +30,7 @@ spec:
             values:
               aud: lfx-v2-query-service
     - id: "rule:lfx:lfx-v2-query-service"
+      allow_encoded_slashes: "off"
       match:
         methods:
           - GET
@@ -46,6 +48,7 @@ spec:
             values:
               aud: lfx-v2-query-service
     - id: "rule:lfx:lfx-v2-query-service:resources-count"
+      allow_encoded_slashes: "off"
       match:
         methods:
           - GET
@@ -63,6 +66,7 @@ spec:
             values:
               aud: lfx-v2-query-service
     - id: "rule:lfx:lfx-v2-query-service:org-search"
+      allow_encoded_slashes: "off"
       match:
         methods:
           - GET
@@ -79,6 +83,7 @@ spec:
             values:
               aud: lfx-v2-query-service
     - id: "rule:lfx:lfx-v2-query-service:org-suggest"
+      allow_encoded_slashes: "off"
       match:
         methods:
           - GET


### PR DESCRIPTION
This pull request updates the Helm chart for the `lfx-v2-query-service`, primarily to enhance Gateway API compatibility and improve security settings in HTTP routing and ruleset configurations. The changes focus on explicitly specifying API groups and kinds in Gateway and Service references, and on adding a configuration to disallow encoded slashes in several rules.

**Gateway and Service Reference Updates:**

- Explicitly set the `group` and `kind` fields for Gateway references in `httproute.yaml` to comply with Gateway API requirements.
- Explicitly set the `group` and `kind` fields for Service references in backend definitions in `httproute.yaml`. [[1]](diffhunk://#diff-43b917c79e3d566f318e2287cf1c6c0517639485d08e0ba82e7290387f3e3993L37-R41) [[2]](diffhunk://#diff-43b917c79e3d566f318e2287cf1c6c0517639485d08e0ba82e7290387f3e3993L59-R65)

**Security and Ruleset Enhancements:**

- Added `allow_encoded_slashes: "off"` to all rules in `ruleset.yaml` to prevent encoded slashes in URLs, improving security. [[1]](diffhunk://#diff-dd6847f8da2f6eb3b818c7c6b23f853212abfe8bb72887dbc1a10ae48714ff7bR12) [[2]](diffhunk://#diff-dd6847f8da2f6eb3b818c7c6b23f853212abfe8bb72887dbc1a10ae48714ff7bR33) [[3]](diffhunk://#diff-dd6847f8da2f6eb3b818c7c6b23f853212abfe8bb72887dbc1a10ae48714ff7bR51) [[4]](diffhunk://#diff-dd6847f8da2f6eb3b818c7c6b23f853212abfe8bb72887dbc1a10ae48714ff7bR69) [[5]](diffhunk://#diff-dd6847f8da2f6eb3b818c7c6b23f853212abfe8bb72887dbc1a10ae48714ff7bR86)

**Chart Version Update:**

- Bumped the chart version from `0.4.6` to `0.4.7` in `Chart.yaml`.

Issue: LFXV2-511