### PR TITLE
[LFXV2-1211] Add pod annotations and labels support

### DIFF
--- a/charts/lfx-v2-query-service/templates/deployment.yaml
+++ b/charts/lfx-v2-query-service/templates/deployment.yaml
@@ -13,8 +13,15 @@ spec:
       app: lfx-v2-query-service
   template:
     metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         app: lfx-v2-query-service
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name | default .Chart.Name }}
       containers:

--- a/charts/lfx-v2-query-service/values.yaml
+++ b/charts/lfx-v2-query-service/values.yaml
@@ -3,8 +3,16 @@
 ---
 replicaCount: 3
 
+# podAnnotations are additional annotations applied to the pod template.
+# Example:
+#   prometheus.io/scrape: "true"
+#   prometheus.io/port: "8080"
 podAnnotations: {}
 
+# podLabels are additional labels applied to the pod template.
+# Example:
+#   team: platform
+#   environment: production
 podLabels: {}
 
 # Override from CLI/CI: --set image.tag=<git-sha>, etc.

--- a/charts/lfx-v2-query-service/values.yaml
+++ b/charts/lfx-v2-query-service/values.yaml
@@ -3,6 +3,10 @@
 ---
 replicaCount: 3
 
+podAnnotations: {}
+
+podLabels: {}
+
 # Override from CLI/CI: --set image.tag=<git-sha>, etc.
 image:
   repository: ghcr.io/linuxfoundation/lfx-v2-query-service/cmd


### PR DESCRIPTION
## Summary
- Add `podAnnotations` and `podLabels` values to Helm chart (default empty)
- Update deployment template to render pod-level annotations and labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)