### PR TITLE
[LFXV2-1370] Add resource catalog documentation for searchable resource types

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,17 +218,12 @@ Authorization: Bearer <jwt_token>
 - `name`: Resource name or alias (supports typeahead search)
 - `type`: Resource type to filter by
 - `parent`: Parent resource for hierarchical queries
-<<<<<<< HEAD
 - `tags`: Array of tags to filter by (OR logic - matches resources with any of these tags)
 - `tags_all`: Array of tags to filter by (AND logic - matches resources that have all of these tags)
+- `cel_filter`: CEL expression for advanced post-query filtering (see [CEL Filter](#cel-filter) section)
 - `date_field`: Date field to filter on (within data object) - used with date_from and/or date_to
 - `date_from`: Start date (inclusive). Format: ISO 8601 datetime or date-only (YYYY-MM-DD). Date-only uses start of day UTC
 - `date_to`: End date (inclusive). Format: ISO 8601 datetime or date-only (YYYY-MM-DD). Date-only uses end of day UTC
-=======
-- `tags`: Array of tags to filter by (OR logic)
-- `tags_all`: Array of tags where all must match (AND logic)
-- `cel_filter`: CEL expression for advanced post-query filtering (see [CEL Filter](#cel-filter) section)
->>>>>>> 3e45fc4d33aba656a5abe1c3df0d3f2bd0fd6be7
 - `sort`: Sort order (name_asc, name_desc, updated_asc, updated_desc)
 - `page_token`: Pagination token
 - `v`: API version (required)
@@ -253,7 +248,6 @@ Authorization: Bearer <jwt_token>
 }
 ```
 
-<<<<<<< HEAD
 **Date Range Filtering Examples:**
 
 Filter resources updated between two dates (date-only format):
@@ -292,7 +286,7 @@ Authorization: Bearer <jwt_token>
   - For `date_to`: Converts to `2025-01-10T23:59:59Z` (end of day)
 - All dates are inclusive (uses `gte` and `lte` operators)
 - The `date_field` parameter is automatically prefixed with `"data."` to scope to the resource's data object
-=======
+
 #### CEL Filter
 
 The `cel_filter` query parameter enables advanced filtering of search results using Common Expression Language (CEL). CEL is a non-Turing complete expression language designed for safe, fast evaluation of expressions in performance-critical applications.
@@ -405,7 +399,6 @@ Invalid CEL expressions return a 400 Bad Request with details:
   "error": "filter expression failed: ERROR: <input>:1:6: Syntax error: mismatched input 'invalid' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}"
 }
 ```
->>>>>>> 3e45fc4d33aba656a5abe1c3df0d3f2bd0fd6be7
 
 #### Organization Search API
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ make docker-run
 
 ## Usage
 
+### Queryable Resource Types
+
+All resource types searchable via this service are listed in [`docs/resource-catalog.md`](docs/resource-catalog.md), organized by the service that indexes them. Each entry links to that service's indexer contract — the authoritative reference for its data schemas, tags, access control config, and parent references.
+
 ### Running Locally
 
 #### With Mock Implementation (Default for Development)

--- a/docs/resource-catalog.md
+++ b/docs/resource-catalog.md
@@ -42,7 +42,7 @@ GET /query/resources?v=1&type=committee_member&tags=committee_uid:<committee_uid
 ### Find voting members of a committee
 
 ```bash
-GET /query/resources?v=1&type=committee_member&tags=committee_uid:<committee_uid>&tags=voting_status:Voting Rep
+GET /query/resources?v=1&type=committee_member&tags_all=committee_uid:<committee_uid>&tags_all=voting_status:Voting Rep
 ```
 
 ### Find child committees of a parent committee

--- a/docs/resource-catalog.md
+++ b/docs/resource-catalog.md
@@ -1,0 +1,67 @@
+# Resource Catalog
+
+This document is the index of all resource types searchable via the Query Service, organized by the service that indexes them.
+
+Each service owns its indexer contract — the authoritative reference for data schemas, tags, access control, and parent references for its resource types. When a resource type changes, only that service's contract needs updating.
+
+---
+
+## Services
+
+| Service | Resource Types | Indexer Contract |
+|---|---|---|
+| [lfx-v2-committee-service](https://github.com/linuxfoundation/lfx-v2-committee-service) | Committee, Committee Settings, Committee Member, Committee Link, Committee Link Folder | [indexer-contract.md](https://github.com/linuxfoundation/lfx-v2-committee-service/blob/main/docs/indexer-contract.md) |
+
+---
+
+## Adding a New Service
+
+When a new service starts indexing data:
+
+1. Add a `docs/indexer-contract.md` to that service's repo following the [committee-service pattern](https://github.com/linuxfoundation/lfx-v2-committee-service/blob/main/docs/indexer-contract.md)
+2. Add a row to the table above with the service name, resource types, and a link to its contract
+
+---
+
+## Common Query Patterns
+
+The examples below use `/query/resources`. All requests require `v=1` and a valid JWT token.
+
+### Find all committees for a project
+
+```bash
+GET /query/resources?v=1&type=committee&tags=project_uid:<project_uid>
+```
+
+### Find all members of a committee
+
+```bash
+GET /query/resources?v=1&type=committee_member&tags=committee_uid:<committee_uid>
+```
+
+### Find voting members of a committee
+
+```bash
+GET /query/resources?v=1&type=committee_member&tags=committee_uid:<committee_uid>&tags=voting_status:Voting Rep
+```
+
+### Find child committees of a parent committee
+
+```bash
+GET /query/resources?v=1&type=committee&tags=parent_uid:<parent_uid>
+```
+
+### Find members by organization
+
+```bash
+GET /query/resources?v=1&type=committee_member&tags=organization_name:<org_name>
+```
+
+### Advanced filtering with CEL
+
+```bash
+# Find public committees in a specific category
+GET /query/resources?v=1&type=committee&tags=project_uid:<project_uid>&cel_filter=data.category=="TSC"&&data.public==true
+```
+
+For the full list of queryable fields and tags per resource type, refer to the service's indexer contract linked in the table above.


### PR DESCRIPTION
## Overview

Jira Ticket: https://linuxfoundation.atlassian.net/browse/LFXV2-1370

Depends on https://github.com/linuxfoundation/lfx-v2-committee-service/pull/70

This PR introduces docs/resource-catalog.md as the consolidated index of all resource types searchable via the Query Service.                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                           This is an initial version designed to give both humans and agents a single starting point for discovering what is queryable, who owns each resource type, and where to find the full access pattern details — without needing to know which service to look at first.

### What's included                                                                                                                                                                                                                                                                                                          
                  
- A table of services, their resource types, and links to each service's indexer contract                                                                                                                                                                                                                                
- A clear pattern for onboarding new services as they add their own contracts
- Common query patterns against /query/resources using real committee-service tags (committee_uid, project_uid, voting_status, etc.)                                                                                                                                                                                     
    
---
                                                                                                                                                                                                                                                                                                                       
## Note on live documentation                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                           
A live documentation approach — where the resource catalog is automatically kept in sync as services publish new resource types — is currently in study/research phase. Until then, a new row should be added to the catalog table in the same PR that introduces a new service's indexer contract.                      
  
