### PR TITLE
[LFXV2-1443] docs: document filters, filters_all, and filters_or query params in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ Authorization: Bearer <jwt_token>
 - `parent`: Parent resource for hierarchical queries
 - `tags`: Array of tags to filter by (OR logic - matches resources with any of these tags)
 - `tags_all`: Array of tags to filter by (AND logic - matches resources that have all of these tags)
+- `filters`: Array of exact field filters with AND logic (format: `field:value`, e.g. `stage:Active`). Fields are auto-prefixed with `data.`. Prefer `filters_all` going forward
+- `filters_all`: Same as `filters` — AND logic, all filters must match. Explicit preferred alias
+- `filters_or`: Array of exact field filters with OR logic — at least one must match (same `field:value` format)
 - `cel_filter`: CEL expression for advanced post-query filtering (see [CEL Filter](#cel-filter) section)
 - `date_field`: Date field to filter on (within data object) - used with date_from and/or date_to
 - `date_from`: Start date (inclusive). Format: ISO 8601 datetime or date-only (YYYY-MM-DD). Date-only uses start of day UTC

--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ Authorization: Bearer <jwt_token>
 - `parent`: Parent resource for hierarchical queries
 - `tags`: Array of tags to filter by (OR logic - matches resources with any of these tags)
 - `tags_all`: Array of tags to filter by (AND logic - matches resources that have all of these tags)
-- `filters`: Array of exact field filters with AND logic (format: `field:value`, e.g. `stage:Active`). Fields are auto-prefixed with `data.`. Prefer `filters_all` going forward
-- `filters_all`: Same as `filters` — AND logic, all filters must match. Explicit preferred alias
+- `filters`: Legacy/backwards-compatible array of exact field filters with AND logic (format: `field:value`, e.g. `stage:Active`). Fields are auto-prefixed with `data.`
+- `filters_all`: Preferred array of exact field filters with AND logic (same `field:value` format). If both `filters` and `filters_all` are provided, both sets of filters are applied and combined with AND logic
 - `filters_or`: Array of exact field filters with OR logic — at least one must match (same `field:value` format)
 - `cel_filter`: CEL expression for advanced post-query filtering (see [CEL Filter](#cel-filter) section)
 - `date_field`: Date field to filter on (within data object) - used with date_from and/or date_to


### PR DESCRIPTION
## Summary

Documents the `filters`, `filters_all`, and `filters_or` query parameters in the Resource Search API section of the README, which were missing from the parameters list.

- `filters` — AND logic exact field filters (`field:value` format, auto-prefixed with `data.`)
- `filters_all` — explicit preferred alias for `filters`, same AND logic
- `filters_or` — OR logic, at least one filter must match

## Ticket

[LFXV2-1443](https://linuxfoundation.atlassian.net/browse/LFXV2-1443)

[LFXV2-1443]: https://linuxfoundation.atlassian.net/browse/LFXV2-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ