### PR TITLE
fix: avoid double-wrapping already-wrapped errors in QueryResources

### DIFF
--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -52,7 +52,7 @@ func (s *querySvcsrvc) QueryResources(ctx context.Context, p *querysvc.QueryReso
 	criteria, errCriteria := s.payloadToCriteria(ctx, p)
 	if errCriteria != nil {
 		slog.ErrorContext(ctx, "failed to convert payload to criteria", "error", errCriteria)
-		return nil, wrapError(ctx, errCriteria)
+		return nil, errCriteria
 	}
 
 	// Execute search using the service layer

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -136,7 +136,7 @@ func TestQuerySvcsrvc_QueryResources(t *testing.T) {
 				// No setup needed as we expect error during token parsing
 			},
 			expectedError:     true,
-			expectedErrorType: &querysvc.InternalServerError{}, // Changed to match actual behavior
+			expectedErrorType: &querysvc.BadRequestError{},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- `payloadToCriteria` already calls `wrapError` internally and returns a Goa error type
- Calling `wrapError` again on the returned error hit the `default` case and invoked `.Error()` on the Goa type, which returns `""` by design
- This produced a 500 response with `{"message": ""}` for any payload validation error in `QueryResources`
- Fix: return the already-wrapped error directly instead of double-wrapping it

🤖 Generated with [Claude Code](https://claude.ai/code)