### PR TITLE
[LFXV2-1559] fix: sort missing values last regardless of sort direction

### DIFF
--- a/docs/resource-catalog.md
+++ b/docs/resource-catalog.md
@@ -16,7 +16,7 @@ Each service owns its indexer contract — the authoritative reference for data 
 | [lfx-v2-mailing-list-service](https://github.com/linuxfoundation/lfx-v2-mailing-list-service) | Groups.io Service, Groups.io Service Settings, Groups.io Mailing List, Groups.io Mailing List Settings, Groups.io Member, Groups.io Artifact | [indexer-contract.md](https://github.com/linuxfoundation/lfx-v2-mailing-list-service/blob/main/docs/indexer-contract.md) |
 | [lfx-v2-voting-service](https://github.com/linuxfoundation/lfx-v2-voting-service) | Vote, Vote Response | [indexer-contract.md](https://github.com/linuxfoundation/lfx-v2-voting-service/blob/main/docs/indexer-contract.md) |
 | [lfx-v2-survey-service](https://github.com/linuxfoundation/lfx-v2-survey-service) | Survey, Survey Response, Survey Template | [indexer-contract.md](https://github.com/linuxfoundation/lfx-v2-survey-service/blob/main/docs/indexer-contract.md) |
-| [lfx-v2-member-service](https://github.com/linuxfoundation/lfx-v2-member-service) | Membership Tier, Project Membership, Key Contact, B2B Org | [indexer-contract.md](https://github.com/linuxfoundation/lfx-v2-member-service/blob/main/docs/indexer-contract.md) |
+| [lfx-v2-member-service](https://github.com/linuxfoundation/lfx-v2-member-service) | Membership Tier, Project Membership, Key Contact, B2B Org | |
 
 ---
 

--- a/internal/infrastructure/opensearch/template.go
+++ b/internal/infrastructure/opensearch/template.go
@@ -144,7 +144,8 @@ const queryResourceSource = `{
   "sort": [
     {
       {{ .SortBy | quote }}: {
-        "order": {{ .SortOrder | quote }}
+        "order": {{ .SortOrder | quote }},
+        "missing": "_last"
       }
     },
     {"_id": "asc"}


### PR DESCRIPTION
## Summary
- Adds `"missing": "_last"` to all OpenSearch sort specifications so documents without a sort field value always appear at the end of results, whether sorting ascending or descending
- Previously, documents with null/missing `sort_name` would scatter through results (falling back to `_id` tie-breaking), making sort order unpredictable

## Ticket
[LFXV2-1559](https://linear.app/linuxfoundation/issue/LFXV2-1559)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1559]: https://linuxfoundation.atlassian.net/browse/LFXV2-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ