### PR TITLE
fix: set peer.service on OpenSearch spans

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/log v0.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
 	goa.design/clue v1.2.1
 	goa.design/goa/v3 v3.21.1
 	golang.org/x/crypto v0.49.0
@@ -56,7 +57,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.33.0 // indirect

--- a/internal/infrastructure/opensearch/searcher.go
+++ b/internal/infrastructure/opensearch/searcher.go
@@ -22,6 +22,9 @@ import (
 	"github.com/opensearch-project/opensearch-go/v4"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var queryResourceTemplate = template.Must(
@@ -249,11 +252,22 @@ func NewSearcher(ctx context.Context, config Config) (port.ResourceSearcher, err
 	opensearchClient, errpensearchClient := opensearchapi.NewClient(opensearchapi.Config{
 		Client: opensearch.Config{
 			Addresses: []string{config.URL},
-			Transport: otelhttp.NewTransport(&http.Transport{
-				MaxIdleConnsPerHost:   10,
-				ResponseHeaderTimeout: 30 * time.Second,
-				DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
-			}),
+			Transport: otelhttp.NewTransport(
+				&http.Transport{
+					MaxIdleConnsPerHost:   10,
+					ResponseHeaderTimeout: 30 * time.Second,
+					DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+				},
+				// peer.service was removed from OTel semconv in v1.39 (replaced by
+				// resource-level service.name). It is set here as a raw attribute
+				// because Datadog still uses it to label downstream nodes in the
+				// service map; without it, Datadog falls back to server.address
+				// which resolves to the raw AWS VPC hostname.
+				otelhttp.WithSpanOptions(trace.WithAttributes(
+					attribute.String("peer.service", "opensearch"),
+					semconv.DBSystemNameOpenSearch,
+				)),
+			),
 		},
 	})
 	if errpensearchClient != nil {


### PR DESCRIPTION
## Summary

- Datadog traces show the downstream OpenSearch service as the raw AWS VPC hostname (`vpc-...`) instead of `opensearch` because `otelhttp.NewTransport()` was called without options, causing OTel to use the literal hostname from `OPENSEARCH_URL` as `server.address`
- Adds `peer.service="opensearch"` via `otelhttp.WithSpanOptions` on all outbound OpenSearch HTTP spans so Datadog's service map correctly identifies the downstream service
- Promotes `go.opentelemetry.io/otel/trace` from indirect to direct dependency

Closes LFXV2-2051