### PR TITLE
chore: upgrade golangci-lint to v2.12.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOOS := linux
 GOARCH := amd64
 
 # Linting
-GOLANGCI_LINT_VERSION := v2.2.2
+GOLANGCI_LINT_VERSION := v2.12.2
 LINT_TIMEOUT := 10m
 LINT_TOOL=$(shell go env GOPATH)/bin/golangci-lint
 
@@ -54,7 +54,7 @@ apigen: deps #@ Generate API code using Goa
 .PHONY: lint
 lint: ## Run golangci-lint (local Go linting)
 	@echo "Running golangci-lint..."
-	@which golangci-lint >/dev/null 2>&1 || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest)
+	@which golangci-lint >/dev/null 2>&1 || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
 	@golangci-lint run ./... && echo "==> Lint OK"
 
 .PHONY: test

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -594,8 +594,6 @@ func TestQuerySvcsrvc_InterfaceCompliance(t *testing.T) {
 	mockOrgSearcher := mock.NewMockOrganizationSearcher()
 	service := NewQuerySvc(mockResourceSearcher, mockAccessChecker, mock.NewMockResourceFilter(), mockOrgSearcher, mock.NewMockAuthService())
 
-	// This will fail to compile if querySvcsrvc doesn't implement querysvc.Service
-	var _ querysvc.Service = service
-
+	var _ querysvc.Service = (*querySvcsrvc)(nil)
 	assert.NotNil(t, service)
 }

--- a/internal/service/organization_search_test.go
+++ b/internal/service/organization_search_test.go
@@ -759,15 +759,14 @@ func TestOrganizationSearchInterface(t *testing.T) {
 		mockSearcher := mock.NewMockOrganizationSearcher()
 		service := NewOrganizationSearch(mockSearcher)
 
-		// Verify that the service implements the interface
-		var _ OrganizationSearcher = service
+		var _ OrganizationSearcher = (*OrganizationSearch)(nil)
 		assertion.NotNil(service)
 	})
 
 	t.Run("interface methods are callable", func(t *testing.T) {
 		// Setup
 		mockSearcher := mock.NewMockOrganizationSearcher()
-		var service OrganizationSearcher = NewOrganizationSearch(mockSearcher)
+		service := NewOrganizationSearch(mockSearcher)
 
 		ctx := context.Background()
 		criteria := model.OrganizationSearchCriteria{

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -102,7 +102,7 @@ func (c *Client) doRequest(ctx context.Context, reqConfig Request) (*Response, e
 	if err != nil {
 		return nil, fmt.Errorf("HTTP request failed: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Bump golangci-lint from v2.2.2 to v2.12.2 (built with go1.25.10) to resolve build failure against go 1.25.0. Fix four new lint issues surfaced by the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)