### PR TITLE
Fix Datadog trace resource names

### DIFF
--- a/cmd/http.go
+++ b/cmd/http.go
@@ -55,7 +55,9 @@ func handleHTTPServer(ctx context.Context, host string, querySvcEndpoints *query
 							if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
 								labeler.Add(semconv.HTTPRoute(routePattern))
 							}
-							trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+							span := trace.SpanFromContext(r.Context())
+							span.SetAttributes(semconv.HTTPRoute(routePattern))
+							span.SetName(r.Method + " " + routePattern)
 						}
 					}
 				}()

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -11,13 +11,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	"go.opentelemetry.io/otel/trace"
+	"goa.design/clue/debug"
+	goahttp "goa.design/goa/v3/http"
+
 	querysvcsvr "github.com/linuxfoundation/lfx-v2-query-service/gen/http/query_svc/server"
 	querysvc "github.com/linuxfoundation/lfx-v2-query-service/gen/query_svc"
 	"github.com/linuxfoundation/lfx-v2-query-service/internal/middleware"
-
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"goa.design/clue/debug"
-	goahttp "goa.design/goa/v3/http"
 )
 
 // handleHTTPServer starts configures and starts a HTTP server on the given
@@ -35,7 +38,7 @@ func handleHTTPServer(ctx context.Context, host string, querySvcEndpoints *query
 
 	// Build the service HTTP request multiplexer and mount debug and profiler
 	// endpoints in debug mode.
-	var mux goahttp.Muxer
+	var mux goahttp.MiddlewareMuxer
 	{
 		mux = goahttp.NewMuxer()
 		if dbg {
@@ -62,6 +65,29 @@ func handleHTTPServer(ctx context.Context, host string, querySvcEndpoints *query
 		eh := errorHandler(ctx)
 		querySvcServer = querysvcsvr.New(querySvcEndpoints, mux, dec, enc, eh, nil, koHttpDir, koHttpDir, koHttpDir, koHttpDir)
 	}
+
+	// Register route-tagging middleware inside chi's routing chain so that
+	// http.route is set on the OTel span after chi has matched the route pattern.
+	// The span name is also updated here to avoid high-cardinality names from
+	// using raw URL paths (which contain actual path parameter values).
+	// Must be registered before Mount calls per chi convention.
+	// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
+	// during routing (inside ServeHTTP), not before.
+	mux.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+			rctx := chi.RouteContext(r.Context())
+			if rctx != nil {
+				routePattern := rctx.RoutePattern()
+				if routePattern != "" {
+					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+						labeler.Add(semconv.HTTPRoute(routePattern))
+					}
+					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+				}
+			}
+		})
+	})
 
 	// Configure the mux.
 	querysvcsvr.Mount(mux, querySvcServer)

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -41,6 +41,28 @@ func handleHTTPServer(ctx context.Context, host string, querySvcEndpoints *query
 	var mux goahttp.MiddlewareMuxer
 	{
 		mux = goahttp.NewMuxer()
+
+		// Register route-tagging middleware before any mounts so chi sees it
+		// for all routes. Reads RoutePattern after next.ServeHTTP because chi
+		// populates the pattern during routing (inside ServeHTTP), not before.
+		mux.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				defer func() {
+					rctx := chi.RouteContext(r.Context())
+					if rctx != nil {
+						routePattern := rctx.RoutePattern()
+						if routePattern != "" {
+							if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
+								labeler.Add(semconv.HTTPRoute(routePattern))
+							}
+							trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
+						}
+					}
+				}()
+				next.ServeHTTP(w, r)
+			})
+		})
+
 		if dbg {
 			// Mount pprof handlers for memory profiling under /debug/pprof.
 			debug.MountPprofHandlers(debug.Adapt(mux))
@@ -65,29 +87,6 @@ func handleHTTPServer(ctx context.Context, host string, querySvcEndpoints *query
 		eh := errorHandler(ctx)
 		querySvcServer = querysvcsvr.New(querySvcEndpoints, mux, dec, enc, eh, nil, koHttpDir, koHttpDir, koHttpDir, koHttpDir)
 	}
-
-	// Register route-tagging middleware inside chi's routing chain so that
-	// http.route is set on the OTel span after chi has matched the route pattern.
-	// The span name is also updated here to avoid high-cardinality names from
-	// using raw URL paths (which contain actual path parameter values).
-	// Must be registered before Mount calls per chi convention.
-	// Reads RoutePattern after next.ServeHTTP because chi populates the pattern
-	// during routing (inside ServeHTTP), not before.
-	mux.Use(func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			next.ServeHTTP(w, r)
-			rctx := chi.RouteContext(r.Context())
-			if rctx != nil {
-				routePattern := rctx.RoutePattern()
-				if routePattern != "" {
-					if labeler, ok := otelhttp.LabelerFromContext(r.Context()); ok {
-						labeler.Add(semconv.HTTPRoute(routePattern))
-					}
-					trace.SpanFromContext(r.Context()).SetName(r.Method + " " + routePattern)
-				}
-			}
-		})
-	})
 
 	// Configure the mux.
 	querysvcsvr.Mount(mux, querySvcServer)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ go 1.25.0
 
 require (
 	github.com/auth0/go-jwt-middleware/v2 v2.3.0
+	github.com/go-chi/chi/v5 v5.2.2
 	github.com/google/cel-go v0.26.1
 	github.com/google/uuid v1.6.0
 	github.com/nats-io/nats.go v1.43.0
@@ -41,7 +42,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dimfeld/httppath v0.0.0-20170720192232-ee938bf73598 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-chi/chi/v5 v5.2.2 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gohugoio/hashstructure v0.5.0 // indirect


### PR DESCRIPTION
## Summary

- Add chi route-tagging middleware to set `http.route` on OTel spans after chi matches the route pattern
- Update `trace.SpanFromContext().SetName()` with the matched route pattern so Datadog shows `GET /api/v1/queries/{id}` instead of just `GET`
- Change `var mux goahttp.Muxer` to `goahttp.MiddlewareMuxer` to expose the `Use()` method
- Promote `chi/v5` and `otel/trace` from indirect to direct dependencies in `go.mod`

Fixes low-cardinality Datadog trace resource names across the service by reading the chi route pattern post-`ServeHTTP` (the only point at which chi has populated it).

JIRA: [LFXV2-1935](https://linuxfoundation.atlassian.net/browse/LFXV2-1935)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1935]: https://linuxfoundation.atlassian.net/browse/LFXV2-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ