### PR TITLE
chore: update CODEOWNERS to service-specific team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-# Platform engineering group within LFX engineering.
-* @linuxfoundation/lfx-platform
+* @linuxfoundation/lfx-v2-query-service


### PR DESCRIPTION
This PR updates the code owners of this repository to the smaller-scoped `lfx-v2-query-service` team.