### PR TITLE
refactor(converters): deduplicate filter and date parsing across criteria builders

### DIFF
--- a/cmd/service/converters.go
+++ b/cmd/service/converters.go
@@ -53,6 +53,69 @@ func parseDateFilter(dateStr string, isEndDate bool) (string, error) {
 	return t.Format(time.RFC3339), nil
 }
 
+// commonQueryParams holds the query fields shared by QueryResourcesPayload and
+// QueryResourcesCountPayload. Populate it from either payload type and pass it
+// to applyCommonFields to avoid repeating filter-parsing and date-handling logic
+// in every converter.
+type commonQueryParams struct {
+	Name       *string
+	Parent     *string
+	Type       *string
+	Tags       []string
+	TagsAll    []string
+	Filters    []string
+	FiltersAll []string
+	FiltersOr  []string
+	DateField  *string
+	DateFrom   *string
+	DateTo     *string
+}
+
+// applyCommonFields populates the shared filter and date fields on criteria from p.
+// It returns an error for invalid filter formats or date parameter combinations.
+// It does not log; callers are responsible for logging and wrapping the error.
+func applyCommonFields(criteria *model.SearchCriteria, p commonQueryParams) error {
+	filters, filtersAll, filtersOr, err := parseFilterSets(p.Filters, p.FiltersAll, p.FiltersOr)
+	if err != nil {
+		return err
+	}
+	criteria.Name = p.Name
+	criteria.Parent = p.Parent
+	criteria.ResourceType = p.Type
+	criteria.Tags = p.Tags
+	criteria.TagsAll = p.TagsAll
+	criteria.Filters = filters
+	criteria.FiltersAll = filtersAll
+	criteria.FiltersOr = filtersOr
+
+	if (p.DateFrom != nil || p.DateTo != nil) && p.DateField == nil {
+		return fmt.Errorf("date_field is required when using date_from or date_to")
+	}
+
+	if p.DateField != nil {
+		prefixedField := "data." + *p.DateField
+		criteria.DateField = &prefixedField
+
+		if p.DateFrom != nil {
+			normalizedFrom, err := parseDateFilter(*p.DateFrom, false)
+			if err != nil {
+				return fmt.Errorf("invalid date_from: %w", err)
+			}
+			criteria.DateFrom = &normalizedFrom
+		}
+
+		if p.DateTo != nil {
+			normalizedTo, err := parseDateFilter(*p.DateTo, true)
+			if err != nil {
+				return fmt.Errorf("invalid date_to: %w", err)
+			}
+			criteria.DateTo = &normalizedTo
+		}
+	}
+
+	return nil
+}
+
 // parseFilterSets parses the three filter params (filters, filters_all, filters_or) in one call.
 // Returns an error that already includes the param name for context.
 func parseFilterSets(filters, filtersAll, filtersOr []string) ([]model.FieldFilter, []model.FieldFilter, []model.FieldFilter, error) {
@@ -99,27 +162,25 @@ func parseFilters(filters []string) ([]model.FieldFilter, error) {
 
 // payloadToCriteria converts the generated payload to domain search criteria
 func (s *querySvcsrvc) payloadToCriteria(ctx context.Context, p *querysvc.QueryResourcesPayload) (model.SearchCriteria, error) {
-	filters, filtersAll, filtersOr, err := parseFilterSets(p.Filters, p.FiltersAll, p.FiltersOr)
-	if err != nil {
-		slog.ErrorContext(ctx, "failed to parse filters", "error", err)
-		return model.SearchCriteria{}, wrapError(ctx, err)
-	}
-
 	criteria := model.SearchCriteria{
-		Name:         p.Name,
-		Parent:       p.Parent,
-		ResourceType: p.Type,
-		Tags:         p.Tags,
-		TagsAll:      p.TagsAll,
-		Filters:      filters,
-		FiltersAll:   filtersAll,
-		FiltersOr:    filtersOr,
 		CelFilter:    p.CelFilter,
 		FilterGrants: p.FilterGrants,
 		SortBy:       p.Sort,
 		PageToken:    p.PageToken,
 		PageSize:     p.PageSize,
 	}
+
+	params := commonQueryParams{
+		Name: p.Name, Parent: p.Parent, Type: p.Type,
+		Tags: p.Tags, TagsAll: p.TagsAll,
+		Filters: p.Filters, FiltersAll: p.FiltersAll, FiltersOr: p.FiltersOr,
+		DateField: p.DateField, DateFrom: p.DateFrom, DateTo: p.DateTo,
+	}
+	if err := applyCommonFields(&criteria, params); err != nil {
+		slog.ErrorContext(ctx, "invalid query parameters", "error", err)
+		return model.SearchCriteria{}, wrapError(ctx, err)
+	}
+
 	switch p.Sort {
 	case "name_asc":
 		criteria.SortBy = "sort_name"
@@ -151,40 +212,6 @@ func (s *querySvcsrvc) payloadToCriteria(ctx context.Context, p *querysvc.QueryR
 		)
 	}
 
-	// Validate date filtering parameters
-	if (p.DateFrom != nil || p.DateTo != nil) && p.DateField == nil {
-		err := fmt.Errorf("date_field is required when using date_from or date_to")
-		slog.ErrorContext(ctx, "invalid date filter parameters", "error", err)
-		return criteria, wrapError(ctx, err)
-	}
-
-	// Handle date filtering parameters
-	if p.DateField != nil {
-		// Auto-prefix with "data." to scope to data object
-		prefixedField := "data." + *p.DateField
-		criteria.DateField = &prefixedField
-
-		// Parse and normalize date_from
-		if p.DateFrom != nil {
-			normalizedFrom, err := parseDateFilter(*p.DateFrom, false)
-			if err != nil {
-				slog.ErrorContext(ctx, "invalid date_from format", "error", err, "date_from", *p.DateFrom)
-				return criteria, wrapError(ctx, err)
-			}
-			criteria.DateFrom = &normalizedFrom
-		}
-
-		// Parse and normalize date_to
-		if p.DateTo != nil {
-			normalizedTo, err := parseDateFilter(*p.DateTo, true)
-			if err != nil {
-				slog.ErrorContext(ctx, "invalid date_to format", "error", err, "date_to", *p.DateTo)
-				return criteria, wrapError(ctx, err)
-			}
-			criteria.DateTo = &normalizedTo
-		}
-	}
-
 	return criteria, nil
 }
 
@@ -211,134 +238,35 @@ func (s *querySvcsrvc) domainResultToResponse(result *model.SearchResult) *query
 }
 
 func (s *querySvcsrvc) payloadToCountPublicCriteria(payload *querysvc.QueryResourcesCountPayload) (model.SearchCriteria, error) {
-	// Parameters used for /<index>/_count search.
 	criteria := model.SearchCriteria{
 		GroupBySize: constants.DefaultBucketSize,
-		// Page size is not passed to this endpoint.
-		PageSize: -1,
-		// For _count, we only want public resources.
-		PublicOnly: true,
+		PageSize:    -1,  // page size is not used for _count
+		PublicOnly:  true, // _count only counts public resources
 	}
-
-	filters, filtersAll, filtersOr, err := parseFilterSets(payload.Filters, payload.FiltersAll, payload.FiltersOr)
-	if err != nil {
-		return criteria, err
+	params := commonQueryParams{
+		Name: payload.Name, Parent: payload.Parent, Type: payload.Type,
+		Tags: payload.Tags, TagsAll: payload.TagsAll,
+		Filters: payload.Filters, FiltersAll: payload.FiltersAll, FiltersOr: payload.FiltersOr,
+		DateField: payload.DateField, DateFrom: payload.DateFrom, DateTo: payload.DateTo,
 	}
-
-	// Set the criteria from the payload
-	criteria.Tags = payload.Tags
-	criteria.TagsAll = payload.TagsAll
-	criteria.Filters = filters
-	criteria.FiltersAll = filtersAll
-	criteria.FiltersOr = filtersOr
-	if payload.Name != nil {
-		criteria.Name = payload.Name
-	}
-	if payload.Type != nil {
-		criteria.ResourceType = payload.Type
-	}
-	if payload.Parent != nil {
-		criteria.Parent = payload.Parent
-	}
-
-	// Validate date filtering parameters
-	if (payload.DateFrom != nil || payload.DateTo != nil) && payload.DateField == nil {
-		return criteria, fmt.Errorf("date_field is required when using date_from or date_to")
-	}
-
-	// Handle date filtering parameters
-	if payload.DateField != nil {
-		// Auto-prefix with "data." to scope to data object
-		prefixedField := "data." + *payload.DateField
-		criteria.DateField = &prefixedField
-
-		// Parse and normalize date_from
-		if payload.DateFrom != nil {
-			normalizedFrom, err := parseDateFilter(*payload.DateFrom, false)
-			if err != nil {
-				return criteria, fmt.Errorf("invalid date_from: %w", err)
-			}
-			criteria.DateFrom = &normalizedFrom
-		}
-
-		// Parse and normalize date_to
-		if payload.DateTo != nil {
-			normalizedTo, err := parseDateFilter(*payload.DateTo, true)
-			if err != nil {
-				return criteria, fmt.Errorf("invalid date_to: %w", err)
-			}
-			criteria.DateTo = &normalizedTo
-		}
-	}
-
-	return criteria, nil
+	return criteria, applyCommonFields(&criteria, params)
 }
 
 func (s *querySvcsrvc) payloadToCountAggregationCriteria(payload *querysvc.QueryResourcesCountPayload) (model.SearchCriteria, error) {
-	// Parameters used for the "group by" aggregated /<index>/_search search.
 	criteria := model.SearchCriteria{
 		GroupBySize: constants.DefaultBucketSize,
-		// We only want the aggregation, not the actual results.
-		PageSize: 0,
-		// The aggregation results will only count private resources.
-		PrivateOnly: true,
-		// Set the attribute to aggregate on.
-		// Use .keyword subfield for aggregation on text fields
+		PageSize:    0,    // aggregation only; no result hits needed
+		PrivateOnly: true, // aggregation counts only private resources
+		// Use .keyword subfield for aggregation on text fields.
 		GroupBy: "access_check_query.keyword",
 	}
-
-	filters, filtersAll, filtersOr, err := parseFilterSets(payload.Filters, payload.FiltersAll, payload.FiltersOr)
-	if err != nil {
-		return criteria, err
+	params := commonQueryParams{
+		Name: payload.Name, Parent: payload.Parent, Type: payload.Type,
+		Tags: payload.Tags, TagsAll: payload.TagsAll,
+		Filters: payload.Filters, FiltersAll: payload.FiltersAll, FiltersOr: payload.FiltersOr,
+		DateField: payload.DateField, DateFrom: payload.DateFrom, DateTo: payload.DateTo,
 	}
-
-	// Set the criteria from the payload
-	criteria.Tags = payload.Tags
-	criteria.TagsAll = payload.TagsAll
-	criteria.Filters = filters
-	criteria.FiltersAll = filtersAll
-	criteria.FiltersOr = filtersOr
-	if payload.Name != nil {
-		criteria.Name = payload.Name
-	}
-	if payload.Type != nil {
-		criteria.ResourceType = payload.Type
-	}
-	if payload.Parent != nil {
-		criteria.Parent = payload.Parent
-	}
-
-	// Validate date filtering parameters
-	if (payload.DateFrom != nil || payload.DateTo != nil) && payload.DateField == nil {
-		return criteria, fmt.Errorf("date_field is required when using date_from or date_to")
-	}
-
-	// Handle date filtering parameters
-	if payload.DateField != nil {
-		// Auto-prefix with "data." to scope to data object
-		prefixedField := "data." + *payload.DateField
-		criteria.DateField = &prefixedField
-
-		// Parse and normalize date_from
-		if payload.DateFrom != nil {
-			normalizedFrom, err := parseDateFilter(*payload.DateFrom, false)
-			if err != nil {
-				return criteria, fmt.Errorf("invalid date_from: %w", err)
-			}
-			criteria.DateFrom = &normalizedFrom
-		}
-
-		// Parse and normalize date_to
-		if payload.DateTo != nil {
-			normalizedTo, err := parseDateFilter(*payload.DateTo, true)
-			if err != nil {
-				return criteria, fmt.Errorf("invalid date_to: %w", err)
-			}
-			criteria.DateTo = &normalizedTo
-		}
-	}
-
-	return criteria, nil
+	return criteria, applyCommonFields(&criteria, params)
 }
 
 func (s *querySvcsrvc) domainCountResultToResponse(result *model.CountResult) *querysvc.QueryResourcesCountResult {

--- a/cmd/service/converters.go
+++ b/cmd/service/converters.go
@@ -249,7 +249,8 @@ func (s *querySvcsrvc) payloadToCountPublicCriteria(payload *querysvc.QueryResou
 		Filters: payload.Filters, FiltersAll: payload.FiltersAll, FiltersOr: payload.FiltersOr,
 		DateField: payload.DateField, DateFrom: payload.DateFrom, DateTo: payload.DateTo,
 	}
-	return criteria, applyCommonFields(&criteria, params)
+	err := applyCommonFields(&criteria, params)
+	return criteria, err
 }
 
 func (s *querySvcsrvc) payloadToCountAggregationCriteria(payload *querysvc.QueryResourcesCountPayload) (model.SearchCriteria, error) {
@@ -266,7 +267,8 @@ func (s *querySvcsrvc) payloadToCountAggregationCriteria(payload *querysvc.Query
 		Filters: payload.Filters, FiltersAll: payload.FiltersAll, FiltersOr: payload.FiltersOr,
 		DateField: payload.DateField, DateFrom: payload.DateFrom, DateTo: payload.DateTo,
 	}
-	return criteria, applyCommonFields(&criteria, params)
+	err := applyCommonFields(&criteria, params)
+	return criteria, err
 }
 
 func (s *querySvcsrvc) domainCountResultToResponse(result *model.CountResult) *querysvc.QueryResourcesCountResult {

--- a/cmd/service/converters_test.go
+++ b/cmd/service/converters_test.go
@@ -973,6 +973,307 @@ func TestPayloadToCriteriaWithDateFilters(t *testing.T) {
 	}
 }
 
+func TestApplyCommonFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		params        commonQueryParams
+		seed          model.SearchCriteria // pre-populated caller fields
+		expectError   bool
+		errorContains string
+		check         func(*testing.T, model.SearchCriteria)
+	}{
+		{
+			name: "sets name, parent, type",
+			params: commonQueryParams{
+				Name:   stringPtr("my-resource"),
+				Parent: stringPtr("parent-id"),
+				Type:   stringPtr("project"),
+			},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, stringPtr("my-resource"), c.Name)
+				assert.Equal(t, stringPtr("parent-id"), c.Parent)
+				assert.Equal(t, stringPtr("project"), c.ResourceType)
+			},
+		},
+		{
+			name: "parses filters and tags",
+			params: commonQueryParams{
+				Tags:       []string{"active"},
+				TagsAll:    []string{"governance"},
+				Filters:    []string{"status:active"},
+				FiltersAll: []string{"priority:high"},
+				FiltersOr:  []string{"region:us"},
+			},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, []string{"active"}, c.Tags)
+				assert.Equal(t, []string{"governance"}, c.TagsAll)
+				assert.Equal(t, []model.FieldFilter{{Field: "data.status", Value: "active"}}, c.Filters)
+				assert.Equal(t, []model.FieldFilter{{Field: "data.priority", Value: "high"}}, c.FiltersAll)
+				assert.Equal(t, []model.FieldFilter{{Field: "data.region", Value: "us"}}, c.FiltersOr)
+			},
+		},
+		{
+			name: "date range with ISO 8601",
+			params: commonQueryParams{
+				DateField: stringPtr("updated_at"),
+				DateFrom:  stringPtr("2025-01-10T00:00:00Z"),
+				DateTo:    stringPtr("2025-01-28T23:59:59Z"),
+			},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, stringPtr("data.updated_at"), c.DateField)
+				assert.Equal(t, stringPtr("2025-01-10T00:00:00Z"), c.DateFrom)
+				assert.Equal(t, stringPtr("2025-01-28T23:59:59Z"), c.DateTo)
+			},
+		},
+		{
+			name: "date range with date-only format",
+			params: commonQueryParams{
+				DateField: stringPtr("created_at"),
+				DateFrom:  stringPtr("2025-01-10"),
+				DateTo:    stringPtr("2025-01-28"),
+			},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, stringPtr("data.created_at"), c.DateField)
+				assert.Equal(t, stringPtr("2025-01-10T00:00:00Z"), c.DateFrom)
+				assert.Equal(t, stringPtr("2025-01-28T23:59:59Z"), c.DateTo)
+			},
+		},
+		{
+			name: "date_field only (no date_from or date_to)",
+			params: commonQueryParams{
+				DateField: stringPtr("updated_at"),
+			},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, stringPtr("data.updated_at"), c.DateField)
+				assert.Nil(t, c.DateFrom)
+				assert.Nil(t, c.DateTo)
+			},
+		},
+		{
+			name:          "date_from without date_field returns error",
+			params:        commonQueryParams{DateFrom: stringPtr("2025-01-10")},
+			expectError:   true,
+			errorContains: "date_field is required",
+		},
+		{
+			name:          "date_to without date_field returns error",
+			params:        commonQueryParams{DateTo: stringPtr("2025-01-28")},
+			expectError:   true,
+			errorContains: "date_field is required",
+		},
+		{
+			name:          "invalid filter format returns error",
+			params:        commonQueryParams{Filters: []string{"no-colon"}},
+			expectError:   true,
+			errorContains: "invalid filter",
+		},
+		{
+			name:          "invalid date_from returns error",
+			params:        commonQueryParams{DateField: stringPtr("f"), DateFrom: stringPtr("not-a-date")},
+			expectError:   true,
+			errorContains: "invalid date_from",
+		},
+		{
+			name:          "invalid date_to returns error",
+			params:        commonQueryParams{DateField: stringPtr("f"), DateTo: stringPtr("01/28/2025")},
+			expectError:   true,
+			errorContains: "invalid date_to",
+		},
+		{
+			name:   "preserves caller-set fields in seed criteria",
+			params: commonQueryParams{},
+			seed:   model.SearchCriteria{PageSize: 42, PublicOnly: true},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, 42, c.PageSize)
+				assert.True(t, c.PublicOnly)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			criteria := tc.seed
+			err := applyCommonFields(&criteria, tc.params)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			if tc.check != nil {
+				tc.check(t, criteria)
+			}
+		})
+	}
+}
+
+func TestPayloadToCountPublicCriteria(t *testing.T) {
+	mockResourceSearcher := mock.NewMockResourceSearcher()
+	mockAccessChecker := mock.NewMockAccessControlChecker()
+	mockOrgSearcher := mock.NewMockOrganizationSearcher()
+	mockAuth := mock.NewMockAuthService()
+	service := NewQuerySvc(mockResourceSearcher, mockAccessChecker, mock.NewMockResourceFilter(), mockOrgSearcher, mockAuth)
+	svc := service.(*querySvcsrvc)
+
+	tests := []struct {
+		name          string
+		payload       *querysvc.QueryResourcesCountPayload
+		expectError   bool
+		errorContains string
+		check         func(*testing.T, model.SearchCriteria)
+	}{
+		{
+			name:    "empty payload sets public-only defaults",
+			payload: &querysvc.QueryResourcesCountPayload{},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.True(t, c.PublicOnly)
+				assert.Equal(t, -1, c.PageSize)
+				assert.Equal(t, constants.DefaultBucketSize, c.GroupBySize)
+			},
+		},
+		{
+			name: "sets name, parent, type from payload",
+			payload: &querysvc.QueryResourcesCountPayload{
+				Name:   stringPtr("my-project"),
+				Parent: stringPtr("p1"),
+				Type:   stringPtr("project"),
+			},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, stringPtr("my-project"), c.Name)
+				assert.Equal(t, stringPtr("p1"), c.Parent)
+				assert.Equal(t, stringPtr("project"), c.ResourceType)
+			},
+		},
+		{
+			name: "date range is applied",
+			payload: &querysvc.QueryResourcesCountPayload{
+				DateField: stringPtr("created_at"),
+				DateFrom:  stringPtr("2025-01-01"),
+				DateTo:    stringPtr("2025-12-31"),
+			},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, stringPtr("data.created_at"), c.DateField)
+				assert.NotNil(t, c.DateFrom)
+				assert.NotNil(t, c.DateTo)
+			},
+		},
+		{
+			name:          "invalid filter returns error",
+			payload:       &querysvc.QueryResourcesCountPayload{Filters: []string{"bad"}},
+			expectError:   true,
+			errorContains: "invalid filter",
+		},
+		{
+			name:          "date_from without date_field returns error",
+			payload:       &querysvc.QueryResourcesCountPayload{DateFrom: stringPtr("2025-01-01")},
+			expectError:   true,
+			errorContains: "date_field is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := svc.payloadToCountPublicCriteria(tc.payload)
+			if tc.expectError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			if tc.check != nil {
+				tc.check(t, result)
+			}
+		})
+	}
+}
+
+func TestPayloadToCountAggregationCriteria(t *testing.T) {
+	mockResourceSearcher := mock.NewMockResourceSearcher()
+	mockAccessChecker := mock.NewMockAccessControlChecker()
+	mockOrgSearcher := mock.NewMockOrganizationSearcher()
+	mockAuth := mock.NewMockAuthService()
+	service := NewQuerySvc(mockResourceSearcher, mockAccessChecker, mock.NewMockResourceFilter(), mockOrgSearcher, mockAuth)
+	svc := service.(*querySvcsrvc)
+
+	tests := []struct {
+		name          string
+		payload       *querysvc.QueryResourcesCountPayload
+		expectError   bool
+		errorContains string
+		check         func(*testing.T, model.SearchCriteria)
+	}{
+		{
+			name:    "empty payload sets private-only aggregation defaults",
+			payload: &querysvc.QueryResourcesCountPayload{},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.True(t, c.PrivateOnly)
+				assert.Equal(t, 0, c.PageSize)
+				assert.Equal(t, "access_check_query.keyword", c.GroupBy)
+				assert.Equal(t, constants.DefaultBucketSize, c.GroupBySize)
+			},
+		},
+		{
+			name: "sets name, parent, type from payload",
+			payload: &querysvc.QueryResourcesCountPayload{
+				Name:   stringPtr("my-project"),
+				Parent: stringPtr("p1"),
+				Type:   stringPtr("project"),
+			},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, stringPtr("my-project"), c.Name)
+				assert.Equal(t, stringPtr("p1"), c.Parent)
+				assert.Equal(t, stringPtr("project"), c.ResourceType)
+			},
+		},
+		{
+			name: "date range is applied",
+			payload: &querysvc.QueryResourcesCountPayload{
+				DateField: stringPtr("updated_at"),
+				DateFrom:  stringPtr("2025-06-01"),
+			},
+			check: func(t *testing.T, c model.SearchCriteria) {
+				assert.Equal(t, stringPtr("data.updated_at"), c.DateField)
+				assert.NotNil(t, c.DateFrom)
+				assert.Nil(t, c.DateTo)
+			},
+		},
+		{
+			name:          "invalid filters_all returns error",
+			payload:       &querysvc.QueryResourcesCountPayload{FiltersAll: []string{"no-colon"}},
+			expectError:   true,
+			errorContains: "invalid filter",
+		},
+		{
+			name:          "date_to without date_field returns error",
+			payload:       &querysvc.QueryResourcesCountPayload{DateTo: stringPtr("2025-12-31")},
+			expectError:   true,
+			errorContains: "date_field is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := svc.payloadToCountAggregationCriteria(tc.payload)
+			if tc.expectError {
+				assert.Error(t, err)
+				if tc.errorContains != "" {
+					assert.Contains(t, err.Error(), tc.errorContains)
+				}
+				return
+			}
+			assert.NoError(t, err)
+			if tc.check != nil {
+				tc.check(t, result)
+			}
+		})
+	}
+}
+
 // Helper function to create string pointers
 func stringPtr(s string) *string {
 	return &s


### PR DESCRIPTION
## Summary

- Introduces `commonQueryParams` struct and `applyCommonFields` helper to eliminate the copy-pasted filter-parsing and date-handling logic that lived identically in `payloadToCriteria`, `payloadToCountPublicCriteria`, and `payloadToCountAggregationCriteria`.
- Adding a new query parameter now requires a single edit instead of three, directly reducing the blast radius flagged in the maintainability audit.
- `payloadToCountPublicCriteria` and `payloadToCountAggregationCriteria` are each reduced to ~5 lines of distinct logic.

## Changes

- `cmd/service/converters.go` — new `commonQueryParams` struct + `applyCommonFields`; three converters simplified to call the shared helper.
- `cmd/service/converters_test.go` — `TestApplyCommonFields` (11 cases); `TestPayloadToCountPublicCriteria` (5 cases); `TestPayloadToCountAggregationCriteria` (5 cases), both previously untested.

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Zero lint issues (`golangci-lint run ./cmd/service/...`)
- [x] New `TestApplyCommonFields` covers all shared logic paths (filters, tags, dates, error cases, seed-criteria preservation)
- [x] New count-converter tests verify defaults, field mapping, date delegation, and error propagation

Resolves [LFXV2-2988](https://linuxfoundation.atlassian.net/browse/LFXV2-2988)

Made with [Cursor](https://cursor.com)

[LFXV2-2988]: https://linuxfoundation.atlassian.net/browse/LFXV2-2988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ